### PR TITLE
Some improvements

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -40,7 +40,7 @@ if cc.has_function(
 else
   gst_barcortp_sources += 'gst_object_set_properties_from_uri_query_parameters.c'
   gst_barcortp_headers += 'gst_object_set_properties_from_uri_query_parameters.h'
-  define_c_flags = ''
+  define_c_flags = []
 endif
 
 gst_barcortp = shared_library('gstbarcortp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,7 +45,6 @@ endif
 
 gst_barcortp = shared_library('gstbarcortp',
   gst_barcortp_sources,
-  version: pkg_version,
   dependencies: gst_barcortp_dependencies,
   include_directories: config_h_dir,
   install: true,


### PR DESCRIPTION
2 issues I had compiling this plugin:
- Normal gstreamer plugins are just .so modules, and not versioned, so I changed this in the meson.build
- If you pass '' to cflags, it's passed to cflags as literally '', in stead of passing nothing, which makes it fail -> arm-fslc-linux-gnueabi-gcc: error: : No such file or directory
an empty argument is set by using []
